### PR TITLE
Adjusted genVolt, genFreq, added acCouplePower and genPower sensors

### DIFF
--- a/custom_components/eg4_inverter/definitions.py
+++ b/custom_components/eg4_inverter/definitions.py
@@ -352,15 +352,29 @@ RUNTIME_SENSORS = [
     },
     {
         "type": "sensor",
+        "key": "acCouplePower",
+        "name": "AC Coupled Power", # Micro-inverters are connected to the Inverter's Generator AC port
+        "unit": UnitOfPower.WATT,
+    },
+    {
+        "type": "sensor",
+        "key": "genPower",
+        "name": "Generator Power",
+        "unit": UnitOfPower.WATT,
+    },
+    {
+        "type": "sensor",
         "key": "genVolt",
         "name": "Generator Voltage",
         "unit": UnitOfElectricPotential.VOLT,
+        "scale": 0.1,
     },
     {
         "type": "sensor",
         "key": "genFreq",
         "name": "Generator Frequency",
         "unit": UnitOfFrequency.HERTZ,
+        "scale": 0.01,
     },
     {
         "type": "sensor",


### PR DESCRIPTION
Adjusted genVolt and genFreq scales (off by 10 and 100, respectively) Added acCouplePower and genPower sensors. Micro-inverters are connected to the Gen AC input. This change will allow to read the current solar production being used to charge the battery/power loads.